### PR TITLE
Drop not used Jira scope

### DIFF
--- a/lib/oauth-jira-cloud.mjs
+++ b/lib/oauth-jira-cloud.mjs
@@ -5,7 +5,6 @@ const JIRA_SCOPE = [
   'read:group:jira',
   'read:avatar:jira',
   'read:user:jira',
-  'read:account',
   'read:jira-user',
   'read:jira-work',
 ].join(' ');


### PR DESCRIPTION
Drop permission in Jira which is not used.

### Fixes
> paste links to issues/tasks in project management
- []()

### Features
Part of [in Jira/confluence case, does customer actually NEED to fill access_tokn](https://app.asana.com/1/27145998307022/project/1201039336231823/task/1211346064398070)

### Change implications

- dependencies added/changed? **yes (explain) / no**
